### PR TITLE
index: Add a csv-table that has episode timings

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,10 +25,13 @@ command-line course Git course such as
 course](https://coderefinery.github.io/git-intro/).  Check out our
 [other upcoming workshops](https://coderefinery.org/workshops/upcoming/).
 
+## Episodes
+
 ```{toctree}
 ---
 caption: Episodes
 maxdepth: 1
+hidden:
 ---
 
 basics
@@ -38,6 +41,16 @@ contributing
 doi
 websites
 ```
+
+```{csv-table}
+20 min , {doc}`basics`
+30 min , {doc}`creating-using-web`
+40 min , {doc}`creating-using-desktop`
+60 min , {doc}`contributing`
+30 min , {doc}`doi`
+30 min , {doc}`websites`
+```
+
 
 ```{toctree}
 ---


### PR DESCRIPTION
- Hide auto-generated toctree
- Duplicate that information in a csv-table directive
- Add timings there (format can be updated)
- This means we have to maintain two places of information, but the
  effort is minimal and doesn't include things such as the actual page
  titles.
- Timings are maintained on the index, instead of in page metadata.
  Perhaps this makes it even easier to browse, if you look at it more
  from a whole-lesson perspective instead of a per-lesson perspective.